### PR TITLE
Try more names for libarchive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 addons:
   apt:
     packages:
-      - libarchive-dev
       - libarchive13
 
 script: bundle exec rake travis

--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -8,7 +8,7 @@ module Archive
     end
 
     extend FFI::Library
-    ffi_lib ["archive", "libarchive.so"]
+    ffi_lib %w{libarchive.so.13 libarchive.13 libarchive.so libarchive archive}
 
     attach_function :archive_version_number, [], :int
     attach_function :archive_version_string, [], :string


### PR DESCRIPTION
This should mean that we'll work on windows, and also on n*x platforms
without needing a dev library