### PR TITLE
Use OR instead of AND for file extraction flags

### DIFF
--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -57,7 +57,7 @@ module Archive
       raise ArgumentError, "Expected Archive::Entry as first argument" unless entry.is_a? Entry
       raise ArgumentError, "Expected Integer as second argument" unless flags.is_a? Integer
 
-      flags &= EXTRACT_FFLAGS
+      flags |= EXTRACT_FFLAGS
       raise Error, @archive if C.archive_read_extract(archive, entry.entry, flags) != C::OK
     end
 

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -91,6 +91,33 @@ class TS_ReadArchive < Test::Unit::TestCase
     end
   end
 
+  def test_extract_no_additional_flags
+    Dir.mktmpdir do |dir|
+      Archive.read_open_filename("data/test.tar.gz") do |ar|
+        Dir.chdir(dir) do
+          ar.each_entry do |e|
+            ar.extract(e)
+            assert_not_equal File.mtime(e.pathname), e.mtime
+          end
+        end
+      end
+    end
+  end
+
+  def test_extract_extract_time
+    Dir.mktmpdir do |dir|
+      Archive.read_open_filename("data/test.tar.gz") do |ar|
+        Dir.chdir(dir) do
+          ar.each_entry do |e|
+            ar.extract(e, Archive::EXTRACT_TIME.to_i)
+            next if e.directory? || e.symbolic_link?
+            assert_equal File.mtime(e.pathname), e.mtime
+          end
+        end
+      end
+    end
+  end
+
   private
 
   def verify_content(ar)


### PR DESCRIPTION
The bitwise AND was effectively always evaluating to 0 and not passing along
flags when they're specified, e.g. from the [libarchive](https://github.com/chef-cookbooks/libarchive/blob/v2.0.0/libraries/helper.rb#L47)
cookbook.

As I read it, it looks like this should be an OR rather than an AND so the
desired flags are always set.

Signed-off-by: Jonathan Hartman <j@hartman.io>