### PR TITLE
Add search pattern for Windows' libarchive-13.dll

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -8,7 +8,7 @@ module Archive
     end
 
     extend FFI::Library
-    ffi_lib %w{libarchive.so.13 libarchive.13 libarchive.so libarchive archive}
+    ffi_lib %w{libarchive.so.13 libarchive.13 libarchive-13 libarchive.so libarchive archive}
 
     attach_function :archive_version_number, [], :int
     attach_function :archive_version_string, [], :string

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -4,17 +4,16 @@ require "test/unit"
 
 class TS_ReadArchive < Test::Unit::TestCase
 
-  CONTENT_SPEC =
-    [
-       ["test/", "directory", 0755, nil ],
-       ["test/b/", "directory", 0755, nil ],
-       ["test/b/c/", "directory", 0755, nil ],
-       ["test/b/c/c.dat", "file", 0600, "\266\262\v_\266\243\305\3601\204\277\351\354\265\003\036\036\365f\377\210\205\032\222\346\370b\360u\032Y\301".b ],
-       ["test/b/c/d/", "directory", 0711, nil ],
-       ["test/b/c/d/d.dat", "symbolic_link", 0777, "../c.dat" ],
-       ["test/b/b.dat", "file", 0640, "s&\245\354(M\331=\270\000!s\355\240\252\355'N\304\343\bY\317\t\274\210\3128\321\347\234!".b ],
-       ["test/a.dat", "file", 0777, "\021\216\231Y\354\236\271\372\336\213\224R\211{D{\277\262\304\211xu\330\\\275@~\035\vSRM".b ]
-      ]
+  CONTENT_SPEC = [
+    ["test/", "directory", 0755, nil ],
+    ["test/b/", "directory", 0755, nil ],
+    ["test/b/c/", "directory", 0755, nil ],
+    ["test/b/c/c.dat", "file", 0600, "\266\262\v_\266\243\305\3601\204\277\351\354\265\003\036\036\365f\377\210\205\032\222\346\370b\360u\032Y\301".b ],
+    ["test/b/c/d/", "directory", 0711, nil ],
+    ["test/b/c/d/d.dat", "symbolic_link", 0777, "../c.dat" ],
+    ["test/b/b.dat", "file", 0640, "s&\245\354(M\331=\270\000!s\355\240\252\355'N\304\343\bY\317\t\274\210\3128\321\347\234!".b ],
+    ["test/a.dat", "file", 0777, "\021\216\231Y\354\236\271\372\336\213\224R\211{D{\277\262\304\211xu\330\\\275@~\035\vSRM".b ]
+  ].freeze
 
   def setup
     File.open("data/test.tar.gz", "rb") do |f|

--- a/test/sets/ts_write.rb
+++ b/test/sets/ts_write.rb
@@ -4,17 +4,16 @@ require "test/unit"
 
 class TS_WriteArchive < Test::Unit::TestCase
 
-  CONTENT_SPEC =
-    [
-       ["test/", "directory", 0755, nil ],
-       ["test/b/", "directory", 0755, nil ],
-       ["test/b/c/", "directory", 0755, nil ],
-       ["test/b/c/c.dat", "file", 0600, "\266\262\v_\266\243\305\3601\204\277\351\354\265\003\036\036\365f\377\210\205\032\222\346\370b\360u\032Y\301".b ],
-       ["test/b/c/d/", "directory", 0711, nil ],
-       ["test/b/c/d/d.dat", "symbolic_link", 0777, "../c.dat" ],
-       ["test/b/b.dat", "file", 0640, "s&\245\354(M\331=\270\000!s\355\240\252\355'N\304\343\bY\317\t\274\210\3128\321\347\234!".b ],
-       ["test/a.dat", "file", 0777, "\021\216\231Y\354\236\271\372\336\213\224R\211{D{\277\262\304\211xu\330\\\275@~\035\vSRM".b ]
-      ]
+  CONTENT_SPEC = [
+    ["test/", "directory", 0755, nil ],
+    ["test/b/", "directory", 0755, nil ],
+    ["test/b/c/", "directory", 0755, nil ],
+    ["test/b/c/c.dat", "file", 0600, "\266\262\v_\266\243\305\3601\204\277\351\354\265\003\036\036\365f\377\210\205\032\222\346\370b\360u\032Y\301".b ],
+    ["test/b/c/d/", "directory", 0711, nil ],
+    ["test/b/c/d/d.dat", "symbolic_link", 0777, "../c.dat" ],
+    ["test/b/b.dat", "file", 0640, "s&\245\354(M\331=\270\000!s\355\240\252\355'N\304\343\bY\317\t\274\210\3128\321\347\234!".b ],
+    ["test/a.dat", "file", 0777, "\021\216\231Y\354\236\271\372\336\213\224R\211{D{\277\262\304\211xu\330\\\275@~\035\vSRM".b ]
+  ].freeze
 
   def test_end_to_end_write_read_tar_gz
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
Fix for Windows libarchive DLL loading issue

In Chef 14.6.47, we have `embedded\bin\libarchive-13.dll`

in 14.5.33 (where the libarchive cookbook works), it was `libarchive.dll`

![2018-11-01 13_53_52-14 5 33 and 14 6 47 - araxis merge](https://user-images.githubusercontent.com/2973273/47869619-c9537180-dddd-11e8-8ed6-85304ff7cf49.png)
