### PR TITLE
Don't ship test and development files in the gem artifact

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*               @chef/client-maintainers
-.expeditor/**   @chef/jex-team
+*                 @chef/client-maintainers
+.expeditor/**     @chef/jex-team
+README.md         @chef/docs-team

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,27 @@
----
 language: ruby
 cache: bundler
 sudo: false
+distro: xenial
 
 addons:
   apt:
     packages:
       - libarchive13
 
-script: bundle exec rake travis
+bundler_args: --jobs 7 --without docs debug
+
 rvm:
   - 2.4.5
   - 2.5.3
+  - 2.6
+  - ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+
 branches:
   only:
     - master
-matrix:
-  fast_finish: true
+
+script: bundle exec rake travis

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,29 @@
 source "https://rubygems.org"
+
 gemspec
 
-group :lint do
-  gem "chefstyle"
+group :docs do
+  gem "yard"
+  gem "redcarpet"
+  gem "github-markup"
 end
 
-group :doc do
-  gem "yard"
+group :test do
+  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "rspec", "~> 3.0"
+  gem "rake"
+  gem "test-unit"
 end
+
+group :debug do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+  gem "rb-readline"
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -13,13 +13,11 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/ffi-libarchive"
   s.license = "Apache-2.0"
 
-  s.files = %w{ LICENSE } + Dir.glob("{lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+  s.files = %w{ LICENSE } + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = %w{lib}
   s.required_ruby_version = ">= 2.4.0"
 
   s.add_dependency "ffi", "~> 1.0"
 
   s.add_development_dependency "bundler"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "test-unit"
 end

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/ffi-libarchive"
   s.license = "Apache-2.0"
 
-  s.files = %w{ Gemfile Rakefile README.md LICENSE VERSION } + Dir.glob("{lib,test}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
+  s.files = %w{ LICENSE } + Dir.glob("{lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = %w{lib}
   s.required_ruby_version = ">= 2.4.0"
 


### PR DESCRIPTION
There's no need to ship all the test and development files in the gem artifact. This change makes it so we only ship the files we need to run the gem.