### PR TITLE
Downgrade the required Ruby version to 2.3+

### DIFF
--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = %w{ LICENSE } + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = %w{lib}
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "ffi", "~> 1.0"
 


### PR DESCRIPTION
## Description
Because the `FFI` only need Ruby 2.0+, so, this gem should only require Ruby 2.3+ instead of 2.4+ currently.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
