### PR TITLE
Optionally clone entries when iterating through an archive

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -123,6 +123,7 @@ module Archive
     attach_function :archive_write_set_bytes_in_last_block, %i{pointer int}, :int
 
     attach_function :archive_entry_new, [], :pointer
+    attach_function :archive_entry_clone, [:pointer], :pointer
     attach_function :archive_entry_free, [:pointer], :void
     attach_function :archive_entry_atime, [:pointer], :time_t
     attach_function :archive_entry_atime_nsec, %i{pointer time_t long}, :void

--- a/lib/ffi-libarchive/entry.rb
+++ b/lib/ffi-libarchive/entry.rb
@@ -34,7 +34,7 @@ module Archive
           result = yield self
           C.archive_entry_free(@entry)
           @entry = nil
-          return result
+          result
         else
           @entry_free[0] = false
           ObjectSpace.define_finalizer(self, Entry.finalizer(@entry, @entry_free))
@@ -462,10 +462,10 @@ module Archive
       value = FFI::MemoryPointer.new :pointer
       size = FFI::MemoryPointer.new :size_t
       if C.archive_entry_xattr_next(entry, name, value, size) != C::OK
-        return nil
+        nil
       else
         # TODO: someday size.read_size_t could work
-        return [name.null? ? nil : name.read_string,
+        [name.null? ? nil : name.read_string,
                 value.null? ? nil : value.get_string(0, size.read_ulong)]
       end
     end

--- a/lib/ffi-libarchive/entry.rb
+++ b/lib/ffi-libarchive/entry.rb
@@ -17,14 +17,14 @@ module Archive
     CHARACTER_SPECIAL = 0020000 #  character device
     FIFO              = 0010000 #  FIFO
 
-    def self.from_pointer(entry)
-      new entry
+    def self.from_pointer(entry, clone: false)
+      new entry, clone: clone
     end
 
-    def initialize(entry = nil)
+    def initialize(entry = nil, clone: false)
       @entry_free = [true]
       if entry
-        @entry = entry
+        @entry = clone ? C.archive_entry_clone(entry) : entry
         yield self if block_given?
       else
         @entry = C.archive_entry_new

--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -109,11 +109,11 @@ module Archive
       raise Error, @archive if C.archive_read_header_position archive
     end
 
-    def next_header
+    def next_header(clone_entry: false)
       entry_ptr = FFI::MemoryPointer.new(:pointer)
       case C.archive_read_next_header(archive, entry_ptr)
       when C::OK
-        Entry.from_pointer entry_ptr.read_pointer
+        Entry.from_pointer entry_ptr.read_pointer, clone: clone_entry
       when C::EOF
         @eof = true
         nil

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -90,6 +90,22 @@ class TS_ReadArchive < Test::Unit::TestCase
     end
   end
 
+  def test_read_entry_not_reused_if_clone_is_specified
+    expect_pathname, expect_type, expect_mode, = CONTENT_SPEC.first
+
+    Archive.read_open_filename("data/test.tar.gz") do |ar|
+      entry = ar.next_header(clone_entry: true)
+      assert_equal expect_pathname, entry.pathname
+      assert_equal entry.send("#{expect_type}?"), true
+      assert_equal expect_mode, (entry.mode & 07777)
+
+      _ = ar.next_header
+      assert_equal expect_pathname, entry.pathname
+      assert_equal entry.send("#{expect_type}?"), true
+      assert_equal expect_mode, (entry.mode & 07777)
+    end
+  end
+
   def test_extract_no_additional_flags
     Dir.mktmpdir do |dir|
       Archive.read_open_filename("data/test.tar.gz") do |ar|


### PR DESCRIPTION
## Description

libarchive's [`archive_read_next_header()`](https://www.freebsd.org/cgi/man.cgi?query=archive_read_header&sektion=3&apropos=0&manpath=FreeBSD+12.1-RELEASE+and+Ports) function re-uses its internal buffer for each call. This can pose a problem for apps which are iterating through an archive, and would like to store entries for later comparison.

This PR adds an optional `clone_entry:` parameter to `Archive::Reader#next_header`. Callers can include this parameter to get a standalone Entry object, produced via [`archive_entry_clone()`](https://www.freebsd.org/cgi/man.cgi?query=archive_entry&sektion=3&apropos=0&manpath=FreeBSD+12.1-RELEASE+and+Ports).

## Related Issue

I wrote https://github.com/chef/ffi-libarchive/issues/29 when I first encountered this issue. I've been using the fix suggested here in a production app for several months now and it's been working well, so I thought I'd open this PR in case it'd be helpful for others. If it's unwelcome, sorry about that—please let me know!
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
