### PR TITLE
Replace specific types with more generic equivalents.

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -156,8 +156,8 @@ module Archive
     attach_function :archive_entry_fflags, %i{pointer pointer pointer}, :void
     attach_function :archive_entry_set_fflags, %i{pointer ulong ulong}, :void
     attach_function :archive_entry_fflags_text, [:pointer], :string
-    attach_function :archive_entry_gid, [:pointer], :gid_t
-    attach_function :archive_entry_set_gid, %i{pointer gid_t}, :void
+    attach_function :archive_entry_gid, [:pointer], :uint
+    attach_function :archive_entry_set_gid, %i{pointer uint}, :void
     attach_function :archive_entry_gname, [:pointer], :string
     attach_function :archive_entry_set_gname, %i{pointer string}, :void
     attach_function :archive_entry_hardlink, [:pointer], :string
@@ -186,8 +186,8 @@ module Archive
     attach_function :archive_entry_strmode, [:pointer], :string
     attach_function :archive_entry_symlink, [:pointer], :string
     attach_function :archive_entry_set_symlink, %i{pointer string}, :void
-    attach_function :archive_entry_uid, [:pointer], :uid_t
-    attach_function :archive_entry_set_uid, %i{pointer uid_t}, :void
+    attach_function :archive_entry_uid, [:pointer], :uint
+    attach_function :archive_entry_set_uid, %i{pointer uint}, :void
     attach_function :archive_entry_uname, [:pointer], :string
     attach_function :archive_entry_set_uname, %i{pointer string}, :void
     attach_function :archive_entry_copy_stat, %i{pointer pointer}, :void


### PR DESCRIPTION
As reported in chef/chef#10061, attempting to use the `archive_file` resource on Windows fails with an error trying to load this gem. I was able to reproduce this error attempting to run the tests for this project in a windows vm:

```
PS C:\vagrant\ffi-libarchive> rake test
C:/opscode/chef-workstation/embedded/lib/ruby/site_ruby/2.7.0/rubygems/defaults/operating_system.rb:25: warning: method redefined; discarding old user_dir
C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/defaults.rb:76: warning: previous definition of user_dir was here
Traceback (most recent call last):
        21: from C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
        20: from C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
        19: from C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
        18: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        17: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        16: from C:/vagrant/ffi-libarchive/test/test_ffi-libarchive.rb:7:in `<top (required)>'
        15: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        14: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        13: from //vboxsvr/vagrant/ffi-libarchive/test/sets/ts_read.rb:1:in `<top (required)>'
        12: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        11: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        10: from //vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive.rb:56:in `<top (required)>'
         9: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
         8: from C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
         7: from //vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/archive.rb:3:in `<top (required)>'
         6: from //vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/archive.rb:4:in `<module:Archive>'
         5: from //vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/archive.rb:159:in `<module:C>'
         4: from C:/Users/vagrant/AppData/Local/chefdk/gem/ruby/2.7.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:252:in `attach_function'
         3: from C:/Users/vagrant/AppData/Local/chefdk/gem/ruby/2.7.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:252:in `each'
         2: from C:/Users/vagrant/AppData/Local/chefdk/gem/ruby/2.7.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:265:in `block in attach_function'
         1: from C:/Users/vagrant/AppData/Local/chefdk/gem/ruby/2.7.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:589:in `find_type'
C:/Users/vagrant/AppData/Local/chefdk/gem/ruby/2.7.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/types.rb:69:in `find_type': unable to resolve type 'gid_t' (TypeError)
rake aborted!
Command failed with status (1)

Tasks: TOP => test
(See full trace by running task with --trace)
```

With this change, the tests run (with unrelated failures):

```
PS C:\vagrant\ffi-libarchive> rake test
C:/opscode/chef-workstation/embedded/lib/ruby/site_ruby/2.7.0/rubygems/defaults/operating_system.rb:25: warning: method redefined; discarding old user_dir
C:/opscode/chef-workstation/embedded/lib/ruby/2.7.0/rubygems/defaults.rb:76: warning: previous definition of user_dir was here
Loaded suite C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader
Started
........E
==========================================================================================================================================================================================
     28:   end
     29:
     30:   def test_read_tar_gz_from_file_with_external_gunzip
  => 31:     Archive.read_open_filename("data/test.tar.gz", "gunzip") do |ar|
     32:       verify_content(ar)
     33:     end
     34:   end
//vboxsvr/vagrant/ffi-libarchive/test/sets/ts_read.rb:31:in `test_read_tar_gz_from_file_with_external_gunzip'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/archive.rb:284:in `read_open_filename'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:7:in `open_filename'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:14:in `open_filename'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:14:in `new'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:58:in `initialize'
Error: test_read_tar_gz_from_file_with_external_gunzip(TS_ReadArchive): Archive::Error: Can't initialize filter; unable to run program "gunzip"
==========================================================================================================================================================================================
.E
==========================================================================================================================================================================================
     40:   end
     41:
     42:   def test_read_tar_gz_from_memory_with_external_gunzip
  => 43:     Archive.read_open_memory(@archive_content, "gunzip") do |ar|
     44:       verify_content(ar)
     45:     end
     46:   end
//vboxsvr/vagrant/ffi-libarchive/test/sets/ts_read.rb:43:in `test_read_tar_gz_from_memory_with_external_gunzip'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/archive.rb:288:in `read_open_memory'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:20:in `open_memory'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:27:in `open_memory'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:27:in `new'
//vboxsvr/vagrant/ffi-libarchive/lib/ffi-libarchive/reader.rb:63:in `initialize'
Error: test_read_tar_gz_from_memory_with_external_gunzip(TS_ReadArchive): Archive::Error: Can't initialize filter; unable to run program "gunzip"
==========================================================================================================================================================================================
...
Finished in 0.1673842 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
14 tests, 224 assertions, 0 failures, 2 errors, 0 pendings, 0 omissions, 0 notifications
85.7143% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
83.64 tests/s, 1338.24 assertions/s
rake aborted!
Command failed with status (1)

Tasks: TOP => test
(See full trace by running task with --trace)
```

I was able to reproduce the chef failure with a small test script:
```
PS C:\vagrant\chef> cat .\test_archive_file_resource.rb
archive_file 'foo.zip' do
  destination '/tmp/foo'
end
```

Running this with the released version of this gem:

```
PS C:\vagrant\chef> bundle exec ruby -Ilib/ .\chef-bin\bin\chef-apply .\test_archive_file_resource.rb
C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:744:in `kill': warning: $SAFE will become a normal global variable in Ruby 3.0 (StructuredWarnings::BuiltInWarning)
C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:744:in `kill': warning: $SAFE will become a normal global variable in Ruby 3.0 (StructuredWarnings::BuiltInWarning)
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * archive_file[foo.zip] action extract

    ================================================================================
    Error executing action `extract` on resource 'archive_file[foo.zip]'
    ================================================================================

    TypeError
    ---------
    unable to resolve type 'gid_t'

    Resource Declaration:
    ---------------------
    # In .\test_archive_file_resource.rb

      1: archive_file 'foo.zip' do
      2:   destination '/tmp/foo'
      3: end

    Compiled Resource:
    ------------------
    # Declared in .\test_archive_file_resource.rb:1:in `run_chef_recipe'

    archive_file("foo.zip") do
      action [:extract]
      default_guard_interpreter :default
      declared_type :archive_file
      cookbook_name "(chef-apply cookbook)"
      recipe_name "(chef-apply recipe)"
      destination "/tmp/foo"
      options [:time]
    end

    System Info:
    ------------
    chef_version=16.2.57
    platform=windows
    platform_version=10.0.17763
    ruby=ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x64-mingw32]
    program_name=./chef-bin/bin/chef-apply
    executable=//vboxsvr/vagrant/chef/chef-bin/bin/chef-apply

[2020-06-26T00:01:53+00:00] FATAL: Stacktrace dumped to C:/Users/vagrant/.chef/cache/chef-stacktrace.out
[2020-06-26T00:01:53+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2020-06-26T00:01:53+00:00] FATAL: TypeError: archive_file[foo.zip] ((chef-apply cookbook)::(chef-apply recipe) line 1) had an error: TypeError: unable to resolve type 'gid_t'
```

versus using the updated version in this PR:
```
PS C:\vagrant\chef> bundle exec ruby -Ilib/ .\chef-bin\bin\chef-apply .\test_archive_file_resource.rb
C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:744:in `kill': warning: $SAFE will become a normal global variable in Ruby 3.0 (StructuredWarnings::BuiltInWarning)
C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:744:in `kill': warning: $SAFE will become a normal global variable in Ruby 3.0 (StructuredWarnings::BuiltInWarning)
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * archive_file[foo.zip] action extract
    - create directory /tmp/foo
    - extract C:/vagrant/chef/foo.zip to /tmp/foo
```

The code change was to switch from two unix-specific types, `gid_t` and `uid_t`, which are [aliased as `unsigned int` in GNU C](https://www.gnu.org/software/libc/manual/html_node/Reading-Persona.html) and which were [removed from libarchive ~10 years ago](https://github.com/libarchive/libarchive/commit/c938a22db226d01fba9964cc2f5ccab9fabc8775). Given this, and since these represent group and user ids which don't exceed 2^16, using a plain unsigned int type seems safe.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>