### PR TITLE
Modern expeditor / buildkite setup

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -5,49 +5,12 @@
 set -ue
 
 export USER="root"
-
-echo "--- dependencies"
 export LANG=C.UTF-8 LANGUAGE=C.UTF-8
-S3_URL="s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}"
-
-pull_s3_file() {
-    aws s3 cp "${S3_URL}/$1" "$1" || echo "Could not pull $1 from S3"
-}
-
-push_s3_file() {
-    if [ -f "$1" ]; then
-        aws s3 cp "$1" "${S3_URL}/$1" || echo "Could not push $1 to S3 for caching."
-    fi
-}
-
-apt-get update -y
-apt-get install awscli -y
 
 echo "--- bundle install"
-pull_s3_file "bundle.tar.gz"
-pull_s3_file "bundle.sha256"
-
-if [ -f bundle.tar.gz ]; then
-  tar -xzf bundle.tar.gz
-fi
-
-if [ -n "${RESET_BUNDLE_CACHE:-}" ]; then
-    rm bundle.sha256
-fi
 
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
 
-echo "--- bundle cache"
-if test -f bundle.sha256 && shasum --check bundle.sha256 --status; then
-    echo "Bundled gems have not changed. Skipping upload to s3"
-else
-    echo "Bundled gems have changed. Uploading to s3"
-    shasum -a 256 Gemfile.lock > bundle.sha256
-    tar -czf bundle.tar.gz vendor/
-    push_s3_file bundle.tar.gz
-    push_s3_file bundle.sha256
-fi
-
 echo "+++ bundle exec task"
-bundle exec $1
+bundle exec $@

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,4 +1,13 @@
 ---
+expeditor:
+  cached_folders:
+    - vendor
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
 
 steps:
 
@@ -31,7 +40,7 @@ steps:
     executor:
       docker:
         image: ruby:2.6-stretch
-- label: run-lint-and-specs-ruby-2.7-rc
+- label: run-lint-and-specs-ruby-2.7
   commands:
     - apt-get update
     - apt-get install -y libarchive13
@@ -39,4 +48,4 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-rc-buster
+        image: ruby:2.7-buster

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,6 @@ end
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer"
+  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
   gem "rb-readline"
 end


### PR DESCRIPTION
- Test on the final ruby 2.7 container
- Use expeditor built in caching
- pin pry deps to allow ruby 2.4 / 2.5 testing

Signed-off-by: Tim Smith <tsmith@chef.io>