### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :docs do
 end
 
 group :test do
-  gem "chefstyle"
+  gem "chefstyle", "1.2.1"
   gem "rspec", "~> 3.0"
   gem "rake"
   gem "test-unit"

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ffi-libarchive/version"

--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -1,4 +1,4 @@
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 module Archive
   module C


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>