### PR TITLE
Extend the reader API to extract to destination

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,8 +18,8 @@ Rake::TestTask.new(:test) do |t|
 end
 
 desc "Run style & unit tests on Travis"
-task travis: %w{style test}
+task travis: %w{test style}
 
 # Default
 desc "Run style, unit"
-task default: %w{style test}
+task default: %w{test style}

--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -97,9 +97,16 @@ module Archive
       raise
     end
 
-    def extract(entry, flags = 0)
+    def extract(entry, flags = 0, destination: nil)
       raise ArgumentError, "Expected Archive::Entry as first argument" unless entry.is_a? Entry
       raise ArgumentError, "Expected Integer as second argument" unless flags.is_a? Integer
+      raise ArgumentError, "Expected String as destination" if destination && !destination.is_a?(String)
+
+      if destination
+        # We update the pathname here so this will change for the caller as a side effect, but this seems convenient and accurate?
+        pathname = C.archive_entry_pathname(entry.entry)
+        C.archive_entry_set_pathname(entry.entry, "#{destination}/#{pathname}")
+      end
 
       flags |= EXTRACT_FFLAGS
       raise Error, @archive if C.archive_read_extract(archive, entry.entry, flags) != C::OK

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -119,6 +119,17 @@ class TS_ReadArchive < Test::Unit::TestCase
     end
   end
 
+  def test_extract_destination
+    Dir.mktmpdir do |dir|
+      Archive.read_open_filename("data/test.tar.gz") do |ar|
+        ar.each_entry do |e|
+          ar.extract(e, destination: dir)
+          assert_not_equal File.mtime(e.pathname), e.mtime
+        end
+      end
+    end
+  end
+
   def test_extract_extract_time
     Dir.mktmpdir do |dir|
       Archive.read_open_filename("data/test.tar.gz") do |ar|


### PR DESCRIPTION
This allow for the removal of Dir.chdir calls wrapping the
extract API, which is non-threadsafe and which Ruby 3.0 has
now dropped the banhammer on.

