### PR TITLE
Remove support for EOL Ruby 2.4

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,16 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.4
-  commands:
-    - apt-get update
-    - apt-get install -y libarchive13
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
 - label: run-lint-and-specs-ruby-2.5
   commands:
     - apt-get update

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-group :docs do
-  gem "yard"
-  gem "redcarpet"
-  gem "github-markup"
-end
-
 group :test do
   gem "chefstyle", "1.7.5"
   gem "rspec", "~> 3.0"

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = %w{ LICENSE } + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = %w{lib}
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5"
 
   s.add_dependency "ffi", "~> 1.0"
-
-  s.add_development_dependency "bundler"
 end


### PR DESCRIPTION
Ruby 2.4 is EOL. It's time to remove support.

Signed-off-by: Tim Smith <tsmith@chef.io>