### PR TITLE
Correcting build/install problems

### DIFF
--- a/ffi-libarchive-universal-mingw32.gemspec
+++ b/ffi-libarchive-universal-mingw32.gemspec
@@ -1,6 +1,10 @@
 gemspec = eval(IO.read(File.expand_path("ffi-libarchive.gemspec", __dir__))) # rubocop: disable Security/Eval
 
-gemspec.platform = Gem::Platform.new(%w{universal mingw32})
+if RUBY_VERSION.match(/2.7/)
+  gemspec.platform = Gem::Platform.new(%w{universal mingw32})
+else
+  gemspec.platform = Gem::Platform.new(%w{universal mingw})
+end
 
 gemspec.files += Dir.glob("{distro}/**/*")
 

--- a/ffi-libarchive-universal-mingw32.gemspec
+++ b/ffi-libarchive-universal-mingw32.gemspec
@@ -1,10 +1,10 @@
 gemspec = eval(IO.read(File.expand_path("ffi-libarchive.gemspec", __dir__))) # rubocop: disable Security/Eval
 
-if RUBY_VERSION.match(/2.7/)
-  gemspec.platform = Gem::Platform.new(%w{universal mingw32})
-else
-  gemspec.platform = Gem::Platform.new(%w{universal mingw})
-end
+gemspec.platform =  if RUBY_VERSION.match(/2.7/)
+                      Gem::Platform.new(%w{universal mingw32})
+                    else
+                      Gem::Platform.new(%w{universal mingw})
+                    end
 
 gemspec.files += Dir.glob("{distro}/**/*")
 

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = %w{ LICENSE } + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = %w{lib}
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.7"
 
-  s.add_dependency "ffi", "~> 1.0"
+  s.add_dependency "ffi", "~> 1.15"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef-client, for a long time, has thrown errors about being able to load ffi-libarchive. Chef was throwing the error because of a loading error during startup. If you invoke irb and then execute "require 'ffi-libarchive' " you get a more detailed error about what's happening

```ruby
irb(main):001:0> require "ffi-libarchive" unless defined?(Archive::Reader)
 (LoadError)4/lib/ruby/gems/3.0.0/gems/ffi-1.15.5-x64-mingw32/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library 'libarchive.so.13': The specified module could not be found.
.
Could not open library 'libarchive.so.13.dll': The specified module could not be found.
.
Could not open library 'libarchive.13': The specified module could not be found.
.
Could not open library 'libarchive.13.dll': The specified module could not be found.
.
Could not open library 'libarchive-13': The specified module could not be found.
.
Could not open library 'libarchive-13.dll': The specified module could not be found.
.
Could not open library 'libarchive.so': The specified module could not be found.
.
Could not open library 'libarchive.so.dll': The specified module could not be found.
.
Could not open library 'libarchive': The specified module could not be found.
.
Could not open library 'libarchive.dll': The specified module could not be found.
.
Could not open library 'archive': The specified module could not be found.
.
Could not open library 'archive.dll': The specified module could not be found.
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/ffi-1.15.5-x64-mingw32/lib/ffi/library.rb:99:in `map'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/ffi-1.15.5-x64-mingw32/lib/ffi/library.rb:99:in `ffi_lib'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/ffi-libarchive-1.1.3/lib/ffi-libarchive/archive.rb:11:in `<module:C>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/ffi-libarchive-1.1.3/lib/ffi-libarchive/archive.rb:4:in `<module:Archive>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/ffi-libarchive-1.1.3/lib/ffi-libarchive/archive.rb:3:in `<top (required)>'
        from <internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/ffi-libarchive-1.1.3/lib/ffi-libarchive.rb:56:in `<top (required)>'
        from <internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
        from <internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
        from <internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
        from (irb):1:in `<main>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
        from C:/Ruby30-x64/bin/irb.cmd:31:in `load'
        from C:/Ruby30-x64/bin/irb.cmd:31:in `<main>'
<internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- ffi-libarchive (LoadError)
        from <internal:C:/Ruby30-x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from (irb):1:in `<main>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
        from C:/Ruby30-x64/bin/irb.cmd:31:in `load'
        from C:/Ruby30-x64/bin/irb.cmd:31:in `<main>'
irb(main):002:0>
```

The Ruby version, the FFI version and the platform requirement had not been updated since 2021. It was necessary to update the platform to distinguish mingw vs mingw32 because the different Ruby versions (2.7 vs 3.x) install incorrectly without this distinction


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
