### PR TITLE
Expose archive format compression methods

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -12,6 +12,7 @@ module Archive
 
     attach_function :archive_version_number, [], :int
     attach_function :archive_version_string, [], :string
+
     attach_function :archive_error_string, [:pointer], :string
     attach_function :archive_errno, [:pointer], :int
 

--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -13,8 +13,12 @@ module Archive
     attach_function :archive_version_number, [], :int
     attach_function :archive_version_string, [], :string
 
-    attach_function :archive_error_string, [:pointer], :string
+    attach_function :archive_compression, [:pointer], :int
+    attach_function :archive_compression_name, [:pointer], :string
     attach_function :archive_errno, [:pointer], :int
+    attach_function :archive_error_string, [:pointer], :string
+    attach_function :archive_format, [:pointer], :int
+    attach_function :archive_format_name, [:pointer], :string
 
     attach_function :archive_read_new, [], :pointer
     attach_function :archive_read_open_filename, %i{pointer string size_t}, :int
@@ -356,12 +360,28 @@ module Archive
     end
     protected :archive
 
+    def compression
+      C.archive_compression(@archive)
+    end
+
+    def compression_name
+      C.archive_compression_name(@archive)
+    end
+
     def error_string
       C.archive_error_string(@archive)
     end
 
     def errno
       C.archive_errno(@archive)
+    end
+
+    def format
+      C.archive_format(@archive)
+    end
+
+    def format_name
+      C.archive_format_name(@archive)
     end
   end
 end

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -25,6 +25,20 @@ class TS_ReadArchive < Test::Unit::TestCase
     RUBY_PLATFORM =~ /mswin|mingw|windows/
   end
 
+  def test_archive_methods
+    return if windows?
+
+    Archive.read_open_filename("data/test.tar.gz") do |ar|
+      # Must read an entry to start reading archive
+      ar.next_header
+
+      assert_equal ar.format, Archive::FORMAT_TAR | Archive::FORMAT_TAR_GNUTAR
+      assert_equal ar.format_name, "GNU tar format"
+      assert_equal ar.compression, Archive::COMPRESSION_GZIP
+      assert_equal ar.compression_name, "gzip"
+    end
+  end
+
   def test_read_tar_gz_from_file
     return if windows?
 


### PR DESCRIPTION
## Description
The format and compression type of an archive may not be known before reading. Libarchive has [robust format support and detection](https://github.com/libarchive/libarchive/wiki/FormatDetection), and contains methods for returning this information. This PR exposes some of those methods via the FFI bindings.

## Related Issue
Fixes #73.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
  - There doesn't seem to be much documentation. Please advise if you would like this documented anywhere specifically.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
