### PR TITLE
Allow opening archive from fd

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -22,6 +22,7 @@ module Archive
 
     attach_function :archive_read_new, [], :pointer
     attach_function :archive_read_open_filename, %i{pointer string size_t}, :int
+    attach_function :archive_read_open_fd, %i{pointer int size_t}, :int
     attach_function :archive_read_open_memory, %i{pointer pointer size_t}, :int
     attach_function :archive_read_open1, [:pointer], :int
     attach_function :archive_read_support_compression_program, %i{pointer string}, :int
@@ -287,6 +288,10 @@ module Archive
 
   def self.read_open_filename(file_name, command = nil, &block)
     Reader.open_filename file_name, command, &block
+  end
+
+  def self.read_open_fd(fd, command = nil, &block)
+    Reader.open_fd fd, command, &block
   end
 
   def self.read_open_memory(string, command = nil, &block)

--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -15,6 +15,19 @@ module Archive
       end
     end
 
+    def self.open_fd(fd, command = nil, strip_components: 0)
+      if block_given?
+        reader = open_fd fd, command, strip_components: strip_components
+        begin
+          yield reader
+        ensure
+          reader.close
+        end
+      else
+        new fd: fd, command: command, strip_components: strip_components
+      end
+    end
+
     def self.open_memory(string, command = nil)
       if block_given?
         reader = open_memory string, command
@@ -66,6 +79,8 @@ module Archive
       case
       when params[:file_name]
         raise Error, @archive if C.archive_read_open_filename(archive, params[:file_name], 1024) != C::OK
+      when params[:fd]
+        raise Error, @archive if C.archive_read_open_fd(archive, params[:fd], 1024) != C::OK
       when params[:memory]
         str = params[:memory]
         @data = FFI::MemoryPointer.new(str.bytesize + 1)

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -55,6 +55,26 @@ class TS_ReadArchive < Test::Unit::TestCase
     end
   end
 
+  def test_read_tar_gz_from_fd
+    return if windows?
+
+    File.open("data/test.tar.gz", "r") do |f|
+      Archive.read_open_fd(f.fileno) do |ar|
+        verify_content(ar)
+      end
+    end
+  end
+
+  def test_read_tar_gz_from_fd_with_external_gunzip
+    return if windows?
+
+    File.open("data/test.tar.gz", "r") do |f|
+      Archive.read_open_fd(f.fileno, "gunzip") do |ar|
+        verify_content(ar)
+      end
+    end
+  end
+
   def test_read_tar_gz_from_memory
     return if windows?
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
We need to read archives from open IO streams, which can be passed to libarchive as an fd.

`read_stream` expects a `reader` object which responds to call, and does not transparently support IO or File instances. Constructing a ruby object of the right shape seems less ideal than passing libarchive an fd.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
