### PR TITLE
Bundle pristine to patch 3.1 ruby

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -11,6 +11,6 @@ echo "--- bundle install"
 
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
-
+bundle pristine ffi
 echo "+++ bundle exec task"
 bundle exec $@


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Pristine install `ffi` to ensure the native gem extension is around for `ffi-libarchive` for Ruby 3.1 test pipeline.

## Related Issue
Related to [BUNDLE_GLOBAL_GEM_CACHE breaks natively compiled libraries](https://github.com/rubygems/rubygems/issues/6616) and build challenges with libyajl2 in CI if another version of [ffi-yajl](https://github.com/chef/ffi-yajl) was already installed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
