### PR TITLE
Allow opening archive from IO instance

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -298,6 +298,10 @@ module Archive
     Reader.open_fd fd, command, &block
   end
 
+  def self.read_open_io(io, command = nil, &block)
+    Reader.open_io io, command, &block
+  end
+
   def self.read_open_memory(string, command = nil, &block)
     Reader.open_memory string, command, &block
   end

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -1,4 +1,5 @@
 require "ffi-libarchive"
+require "stringio"
 require "tmpdir"
 require "test/unit"
 
@@ -72,6 +73,46 @@ class TS_ReadArchive < Test::Unit::TestCase
       Archive.read_open_fd(f.fileno, "gunzip") do |ar|
         verify_content(ar)
       end
+    end
+  end
+
+  def test_read_tar_gz_from_io
+    return if windows?
+
+    File.open("data/test.tar.gz", "r") do |f|
+      Archive.read_open_io(f) do |ar|
+        verify_content(ar)
+      end
+    end
+  end
+
+  def test_read_tar_gz_from_io_with_external_gunzip
+    return if windows?
+
+    File.open("data/test.tar.gz", "r") do |f|
+      Archive.read_open_io(f, "gunzip") do |ar|
+        verify_content(ar)
+      end
+    end
+  end
+
+  def test_read_tar_gz_from_io_no_fileno
+    return if windows?
+
+    string = File.read("data/test.tar.gz")
+
+    assert_raise ArgumentError, "Expected io to respond to #fileno" do
+      Archive.read_open_io(string)
+    end
+  end
+
+  def test_read_tar_gz_from_string_io
+    return if windows?
+
+    io = StringIO.new(File.read("data/test.tar.gz"))
+
+    assert_raise ArgumentError, "Expected io.fileno to return an fd but got nil" do
+      Archive.read_open_io(io)
     end
   end
 


### PR DESCRIPTION
## Description

Allow opening an archive from an `#<IO>` instance, like a `#<File>`. This is different to opening an FD because it will hold a reference to the IO in Ruby, within the Archive instance, ensuring the lifetime of the IO instance is tied to the lifetime of the Archive::Reader instance, as a nice way to ensure libarchive won't read from an FD that Ruby has since closed by GC'ing the IO instance.

Note there is no memory leak etc, the worst that currently happens is an error about reading from a closed FD. But this interface makes the FFI binding a nicer Ruby citizen.

## Related Issue
Previously discussed in #75.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
