### PR TITLE
Don't hide ffi-inliner errors

### DIFF
--- a/lib/ffi-libarchive/entry.rb
+++ b/lib/ffi-libarchive/entry.rb
@@ -181,12 +181,14 @@ module Archive
         raise "ffi-inliner build for copy_stat failed:\n#{e}"
       end
 
-      stat = Archive::Stat.ffi_libarchive_create_lstat(filename)
-      raise Error, "Copy stat failed: #{Archive::Stat.ffi_error}" if stat.null?
+      begin
+        stat = Archive::Stat.ffi_libarchive_create_lstat(filename)
+        raise Error, "Copy stat failed: #{Archive::Stat.ffi_error}" if stat.null?
 
-      C.archive_entry_copy_stat(entry, stat)
-    ensure
-      Archive::Stat.ffi_libarchive_free_stat(stat)
+        C.archive_entry_copy_stat(entry, stat)
+      ensure
+        Archive::Stat.ffi_libarchive_free_stat(stat)
+      end
     end
 
     def copy_pathname(file_name)
@@ -207,12 +209,14 @@ module Archive
         raise "ffi-inliner build for copy_stat failed:\n#{e}"
       end
 
-      stat = Archive::Stat.ffi_libarchive_create_stat(filename)
-      raise Error, "Copy stat failed: #{Archive::Stat.ffi_error}" if stat.null?
+      begin
+        stat = Archive::Stat.ffi_libarchive_create_stat(filename)
+        raise Error, "Copy stat failed: #{Archive::Stat.ffi_error}" if stat.null?
 
-      C.archive_entry_copy_stat(entry, stat)
-    ensure
-      Archive::Stat.ffi_libarchive_free_stat(stat)
+        C.archive_entry_copy_stat(entry, stat)
+      ensure
+        Archive::Stat.ffi_libarchive_free_stat(stat)
+      end
     end
 
     def copy_symlink(slnk)


### PR DESCRIPTION
If ffi-inliner isn't installed the earlier lines of these methods will raise an error and the Archive::Stat module won't be installed, so Archive::Stat.ffi_libarchive_free_stat doens't exist and also raises an error during the ensure block, hiding the originally-raised error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
  - Not easily possible.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
