### PR TITLE
Archive read format raw

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -290,20 +290,20 @@ module Archive
   EXTRACT_SECURE_NOABSOLUTEPATHS = 0x10000
   EXTRACT_CLEAR_NOCHANGE_FFLAGS = 0x20000
 
-  def self.read_open_filename(file_name, command = nil, &block)
-    Reader.open_filename file_name, command, &block
+  def self.read_open_filename(file_name, command = nil, params = {}, &block)
+    Reader.open_filename file_name, command, params, &block
   end
 
-  def self.read_open_fd(fd, command = nil, &block)
-    Reader.open_fd fd, command, &block
+  def self.read_open_fd(fd, command = nil, params = {}, &block)
+    Reader.open_fd fd, command, params, &block
   end
 
-  def self.read_open_memory(string, command = nil, &block)
-    Reader.open_memory string, command, &block
+  def self.read_open_memory(string, command = nil, params = {}, &block)
+    Reader.open_memory string, command, params, &block
   end
 
-  def self.read_open_stream(reader, &block)
-    Reader.open_stream reader, &block
+  def self.read_open_stream(reader, command = nil, params = {}, &block)
+    Reader.open_stream reader, command, params, &block
   end
 
   def self.write_open_filename(file_name, compression, format, &block)

--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -41,16 +41,16 @@ module Archive
       end
     end
 
-    def self.open_stream(reader)
+    def self.open_stream(reader, command = nil)
       if block_given?
-        reader = open_stream reader
+        reader = open_stream reader, command
         begin
           yield reader
         ensure
           reader.close
         end
       else
-        new reader: reader
+        new reader: reader, command: command
       end
     end
 

--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -43,7 +43,7 @@ module Archive
 
     def self.open_stream(reader)
       if block_given?
-        reader = new reader: reader
+        reader = open_stream reader
         begin
           yield reader
         ensure

--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -2,9 +2,9 @@ module Archive
   class Reader < BaseArchive
     private_class_method :new
 
-    def self.open_filename(file_name, command = nil, strip_components: 0)
+    def self.open_filename(file_name, command = nil, strip_components: 0, raw: false)
       if block_given?
-        reader = open_filename file_name, command, strip_components: strip_components
+        reader = open_filename file_name, command, strip_components: strip_components, raw: raw
         begin
           yield reader
         ensure
@@ -15,42 +15,42 @@ module Archive
       end
     end
 
-    def self.open_fd(fd, command = nil, strip_components: 0)
+    def self.open_fd(fd, command = nil, strip_components: 0, raw: false)
       if block_given?
-        reader = open_fd fd, command, strip_components: strip_components
+        reader = open_fd fd, command, strip_components: strip_components, raw: raw
         begin
           yield reader
         ensure
           reader.close
         end
       else
-        new fd: fd, command: command, strip_components: strip_components
+        new fd: fd, command: command, strip_components: strip_components, raw: raw
       end
     end
 
-    def self.open_memory(string, command = nil)
+    def self.open_memory(string, command = nil, raw: false)
       if block_given?
-        reader = open_memory string, command
+        reader = open_memory string, command, raw: raw
         begin
           yield reader
         ensure
           reader.close
         end
       else
-        new memory: string, command: command
+        new memory: string, command: command, raw: raw
       end
     end
 
-    def self.open_stream(reader, command = nil)
+    def self.open_stream(reader, command = nil, raw: false)
       if block_given?
-        reader = open_stream reader, command
+        reader = open_stream reader, command, raw: raw
         begin
           yield reader
         ensure
           reader.close
         end
       else
-        new reader: reader, command: command
+        new reader: reader, command: command, raw: raw
       end
     end
 
@@ -74,7 +74,11 @@ module Archive
         raise Error, @archive if C.archive_read_support_compression_all(archive) != C::OK
       end
 
-      raise Error, @archive if C.archive_read_support_format_all(archive) != C::OK
+      if params[:raw]
+        raise Error, @archive if C.archive_read_support_format_raw(archive) != C::OK
+      else
+        raise Error, @archive if C.archive_read_support_format_all(archive) != C::OK
+      end
 
       case
       when params[:file_name]

--- a/test/sets/ts_read.rb
+++ b/test/sets/ts_read.rb
@@ -1,5 +1,6 @@
 require "ffi-libarchive"
 require "tmpdir"
+require "zlib"
 require "test/unit"
 
 class TS_ReadArchive < Test::Unit::TestCase
@@ -88,6 +89,20 @@ class TS_ReadArchive < Test::Unit::TestCase
 
     Archive.read_open_memory(@archive_content, "gunzip") do |ar|
       verify_content(ar)
+    end
+  end
+
+  def test_read_gz_from_memory
+    data = "test"
+    archive_data = Zlib.gzip(data)
+
+    Archive.read_open_memory(archive_data, nil, raw: true) do |ar|
+      entry = ar.next_header
+      entry_data = ar.read_data
+
+      assert_equal entry.size_is_set?, false
+      assert_equal entry_data.bytesize, data.bytesize
+      assert_equal entry_data, data
     end
   end
 


### PR DESCRIPTION
## Description
Allow reading archives in raw format. Without this change it's impossible to read gzip, bzip2, etc formats which are compression only without monkeying around with `Archive::C.archive_read_support_format_raw` directly.

I've also made some of the reader methods slightly more consistent, in a backwards-compatible way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
