### PR TITLE
Correct return type of archive_read_data (fix RARv5 support)

### DIFF
--- a/lib/ffi-libarchive/archive.rb
+++ b/lib/ffi-libarchive/archive.rb
@@ -82,7 +82,7 @@ module Archive
     attach_function :archive_read_extract, %i{pointer pointer int}, :int
     attach_function :archive_read_header_position, [:pointer], :int
     attach_function :archive_read_next_header, %i{pointer pointer}, :int
-    attach_function :archive_read_data, %i{pointer pointer size_t}, :size_t
+    attach_function :archive_read_data, %i{pointer pointer size_t}, :ssize_t
     attach_function :archive_read_data_into_fd, %i{pointer int}, :int
 
     attach_function :archive_write_new, [], :pointer


### PR DESCRIPTION
Correct the signature of `archive_read_data` to match with the one of libarchive and allow handling errors and warnings.

## Description
The method returns a value of type `ssize_t` instead of `size_t` (compare https://manpages.debian.org/bookworm/libarchive-dev/archive_read_data.3.en.html). The current type `size_t` is unsigned, making it impossible for the code to detect reading errors or warnings. The issue already persists for a long time (compare #4).

We already use the libarchive integration of this gem for a long time. The issue pops repeatedly up on our side. More precise, it makes reading RAR v5 archives impossible if they contain folders.

## Related Issue
Closes #4

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
