### PR TITLE
Avoid modifying a potentially frozen string

### DIFF
--- a/lib/ffi-libarchive/reader.rb
+++ b/lib/ffi-libarchive/reader.rb
@@ -185,7 +185,7 @@ module Archive
           if block_given?
             yield buffer.get_bytes(0, n)
           else
-            data ||= ""
+            data ||= String.new
             data.concat(buffer.get_bytes(0, n))
           end
         end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Ruby 4 is expected to make constant strings frozen by default and ruby 3.4 adds a feature which will warn about attempts to modify such strings when `--enable-frozen-string-literal` is use.

Some testing frameworks are now enabling that be default to allow future problems to be discovered and that let me to discover that this case was trying to append to a constant string.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
