### PR TITLE
Updating for Ruby 3.4 and Cookstyle

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -30,3 +30,23 @@ steps:
         host_os: windows
         shell: ["powershell", "-Command"]
         image: rubydistros/windows-2019:3.1
+
+- label: run-lint-and-specs-ruby-3.4
+  commands:
+    - apt-get update
+    - apt-get install -y libarchive13
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.4
+
+- label: run-specs-ruby-3.4-windows
+  commands:
+   - .expeditor/run_windows_tests.ps1
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        shell: ["powershell", "-Command"]
+        image: rubydistros/windows-2019:3.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - 18-stable
 
 concurrency:
   group: lint-${{ github.ref }}

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ group :test do
   gem "ffi"
 end
 
+group :style do
+  gem "cookstyle", "~> 8.1"
+end
+
 group :debug do
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "cookstyle", ">= 7.32.8"
   gem "rspec", "~> 3.0"
   gem "rake"
   gem "test-unit"

--- a/ffi-libarchive-universal-mingw32.gemspec
+++ b/ffi-libarchive-universal-mingw32.gemspec
@@ -1,7 +1,0 @@
-gemspec = eval(IO.read(File.expand_path("ffi-libarchive.gemspec", __dir__))) # rubocop: disable Security/Eval
-
-gemspec.platform = Gem::Platform.new(%w{universal mingw32})
-
-gemspec.files += Dir.glob("{distro}/**/*")
-
-gemspec

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -15,5 +15,7 @@ Gem::Specification.new do |s|
   s.files = %w{ LICENSE } + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = %w{lib}
   s.required_ruby_version = ">= 3.0"
-  s.add_dependency "ffi", "~> 1.0"
+  s.add_dependency "ffi", "~> 1.17"
+
+  s.add_development_dependency "cookstyle", "~> 8.1"
 end

--- a/ffi-libarchive.gemspec
+++ b/ffi-libarchive.gemspec
@@ -16,6 +16,4 @@ Gem::Specification.new do |s|
   s.require_paths = %w{lib}
   s.required_ruby_version = ">= 3.0"
   s.add_dependency "ffi", "~> 1.17"
-
-  s.add_development_dependency "cookstyle", "~> 8.1"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef-19 is moving to Ruby 3.4 and Cookstyle. We are prepping this gem for that update.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
